### PR TITLE
Fix iOS text adjustment

### DIFF
--- a/source/themes/cards/missing/missing.less
+++ b/source/themes/cards/missing/missing.less
@@ -95,6 +95,7 @@
   margin-bottom: var(--spacing);
   padding: var(--spacing) var(--spacing-one);
   background: var(--color-card-ll);
+  text-align: left;
 
   ul > li,
   ol > li {
@@ -108,4 +109,5 @@
   font-size: var(--font-size-m);
   font-style: italic;
   line-height: var(--line-height-one);
+  text-align: left;
 }

--- a/source/themes/cards/simple/simple.less
+++ b/source/themes/cards/simple/simple.less
@@ -91,6 +91,7 @@
   margin-bottom: var(--spacing);
   padding: var(--spacing) var(--spacing-one);
   background: var(--color-card-ll);
+  text-align: left;
 
   ul > li,
   ol > li {
@@ -104,4 +105,5 @@
   font-size: var(--font-size-m);
   font-style: italic;
   line-height: var(--line-height-one);
+  text-align: left;
 }


### PR DESCRIPTION
Anki iOS defaults to `text-align: center`, this forces `left` in the notes fields.