### PR TITLE
Fix `npm run` comments

### DIFF
--- a/source/data/data-code.html
+++ b/source/data/data-code.html
@@ -3,8 +3,8 @@
      Useful for when you need to make edits to your Anki card:
 
      1. Enter the HTML you need converting to Markdown
-     2. `npm run pandoc-code-reverse`
-     3. View the file in `/build/data/code.md`
+     2. `npm run data-code-reverse`
+     3. View the file in `/build/data/data-code.md`
 
 ========================================================================== -->
 

--- a/source/data/data-code.md
+++ b/source/data/data-code.md
@@ -3,8 +3,8 @@
      Useful for converting `code blocks` or other field data:
 
      1. Enter a Markdown fenced code block (for example)
-     2. `npm run pandoc`
-     3. View the file in `/build/data/code.html`
+     2. `npm run data-code`
+     3. View the file in `/build/data/data-code.html`
 
 ========================================================================== -->
 


### PR DESCRIPTION
Hi @badlydrawnrob, I started using your Anki card template yesterday to create algorithm flashcards and I am loving it. Thank you for all your hard work!

I noticed the comments in `source/data/data-code.html` and `source/data/data-code.md` mentioned using `npm run pandoc` and `npm run pandoc-reverse` which don't seem to be used anymore. I updated them to `npm run data-code` and `npm run data-code-reverse` by using the information in `package.json`.

Hope it helps and thanks again! :D